### PR TITLE
Disable console log during test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "types"
   ],
   "scripts": {
-    "test-native": "NATIVE=true jest --config ./jest.native.json",
-    "test-web": "jest --config ./jest.web.json",
-    "test-web-no-hook": "NOHOOK=true jest --config ./jest.no-hook.json",
+    "test-native": "NATIVE=true jest --config ./jest.native.json --silent",
+    "test-web": "jest --config ./jest.web.json --silent",
+    "test-web-no-hook": "NOHOOK=true jest --config ./jest.no-hook.json --silent",
     "test": "npm run test-web && npm run test-web-no-hook && npm run test-native",
     "example": "node ./scripts/startExample.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",


### PR DESCRIPTION
No-hook-tests print long console.error messages (for the `not.toThrow` cases). This PR disables console logs for tests to clean up the test input. This can only be done with the `--silent` CLI flag and can not be done inside the jest config files.