### PR TITLE
Fix closing tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ import { view, store } from '@risingstack/react-easy-state'
 export default view(() => {
   const counter = store({ num: 0 })
   const increment = () => counter.num++
-  return <button={increment}>{counter.num}</div>
+  return <button={increment}>{counter.num}</button>
 })
 ```
 


### PR DESCRIPTION
Seems like there was probably a mistake made during a documentation refactor

(Really enjoying this library btw)