### PR TITLE
Refactor platform reexports into explicit reexports

### DIFF
--- a/src/platforms/dom.js
+++ b/src/platforms/dom.js
@@ -1,1 +1,2 @@
-export * from 'react-dom';
+// eslint-disable-next-line camelcase
+export { unstable_batchedUpdates } from 'react-dom';

--- a/src/platforms/native.js
+++ b/src/platforms/native.js
@@ -1,1 +1,2 @@
-export * from 'react-native';
+// eslint-disable-next-line camelcase
+export { unstable_batchedUpdates } from 'react-native';


### PR DESCRIPTION
### Proposed changes
Refactor reexports from `platforms/dom.js` and `platforms/native.js` into explicit reexports.


### Why
While trying to build my project with `parcel` and `rollup` I run into a situation where the bundlers cannot resolve the exports of these files. It has been a bit of a pain. As far as I know, `parcel` doesn't allow to manually fix this. On the other hand, `rollup` used to allow a manual fix with an option called `namedExports` which was deprecated in recent versions and it's no longer available.

Here is an example of the error I get from `parcel` (**note**: this only happens with parcel when using the `--experimental-scope-hoisting` flag, or with `parcel v2`):
```
🚨  ../node_modules/@risingstack/react-easy-state/dist/react-platform.js does not export 'unstable_batchedUpdates'
    at replaceExportNode (/Users/orballo/Code/mori/node_modules/parcel/src/scope-hoisting/concat.js:55:13)
    at ReferencedIdentifier (/Users/orballo/Code/mori/node_modules/parcel/src/scope-hoisting/concat.js:342:20)
    at newFn (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/visitors.js:220:17)
    at NodePath._call (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/path/context.js:55:20)
    at NodePath.call (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/path/context.js:42:17)
    at NodePath.visit (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/path/context.js:90:31)
    at TraversalContext.visitQueue (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/context.js:112:16)
    at TraversalContext.visitSingle (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/context.js:84:19)
    at TraversalContext.visit (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/context.js:140:19)
    at Function.traverse.node (/Users/orballo/Code/mori/node_modules/@babel/traverse/lib/index.js:84:17)
```

Regarding `rollup` I found this issue (https://github.com/rollup/rollup/issues/2671). After asking, they suggested that all the reexports should be explicit to avoid this kind of problems.

I'm not sure if this is the ideal solution (I wasn't able to fix it in any other way, though), but if it has no downsides, this changes will at least prevent some pain.

Let me know what you think or if I need to do any further changes.