### PR TITLE
Fix React's StrictMode warning: unmounted component rerender

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -1,4 +1,11 @@
-import { Component, useState, useEffect, useMemo, memo } from 'react';
+import {
+  Component,
+  useState,
+  useEffect,
+  useMemo,
+  memo,
+  useRef,
+} from 'react';
 import {
   observe,
   unobserve,
@@ -36,22 +43,43 @@ export function view(Comp) {
     ReactiveComp = props => {
       // use a dummy setState to update the component
       const [, setState] = useState();
+      // use a ref to store the reaction
+      const reaction = useRef();
       // create a memoized reactive wrapper of the original component (render)
       // at the very first run of the component function
       const render = useMemo(
-        () =>
-          observe(Comp, {
-            scheduler: () => setState({}),
+        () => {
+          reaction.current = observe(Comp, {
+            scheduler: () => {
+              // trigger a new rerender if the component has been mounted
+              if (reaction.current.mounted) setState({});
+              // mark it as changed if the component has not been mounted yet
+              else reaction.current.changedBeforeMounted = true;
+            },
             lazy: true,
-          }),
+          });
+          // initilalize a flag to know if the component was finally mounted
+          reaction.current.mounted = false;
+          // initilalize a flag to know if the was reaction was invalidated
+          // before the component was mounted
+          reaction.current.changedBeforeMounted = false;
+          return reaction.current;
+        },
         // Adding the original Comp here is necessary to make React Hot Reload work
         // it does not affect behavior otherwise
         [Comp],
       );
 
-      // cleanup the reactive connections after the very last render of the component
       useEffect(() => {
-        return () => unobserve(render);
+        // mark the component as mounted.
+        reaction.current.mounted = true;
+
+        // if there was a change before the component was mounted, trigger a
+        // new rerender
+        if (reaction.current.changedBeforeMounted) setState({});
+
+        // cleanup the reactive connections after the very last render of the
+        return () => unobserve(reaction.current);
       }, []);
 
       // the isInsideFunctionComponent flag is used to toggle `store` behavior


### PR DESCRIPTION
## What

This PR fixes the warning that appears in development when using React's StrictMode, explained in more detail in #196.

It doesn't fix the memory leak that will happen in React Concurrent mode. To talk about that I will open a new issue.

## Proposed changes

I have added a flag to check if a component was finally mounted or not. If the component was not mounted, we avoid calling its `setState`.

I have also added another flag for the case when a reaction was invalidated before the component was mounted. If I am not mistaken, this cannot happen in React right now, but it can happen in React Concurrent mode, so why not add it now.