### PR TITLE
test(examples): replace react-native tester

### DIFF
--- a/__tests__/Clock.test.native.jsx
+++ b/__tests__/Clock.test.native.jsx
@@ -1,20 +1,20 @@
 import React, { StrictMode } from 'react';
-import {
-  render,
-  flushMicrotasksQueue,
-} from 'react-native-testing-library';
+
+import renderer from 'react-test-renderer';
+
 import sinon from 'sinon';
 import App from '../examples/native-clock/App';
 
 describe('Clock App', () => {
   const clock = sinon.useFakeTimers();
-  const { getByText, unmount } = render(
+
+  const app = renderer.create(
     <StrictMode>
       <App />
     </StrictMode>,
   );
-  // flush the inital didMount effect
-  flushMicrotasksQueue();
+
+  const { unmount } = app;
 
   const clearIntervalSpy = sinon.spy(global, 'clearInterval');
 
@@ -23,14 +23,16 @@ describe('Clock App', () => {
     clearIntervalSpy.restore();
   });
 
-  test('should update to display the current time every second', () => {
-    expect(getByText('12:00:00 AM')).toBeDefined();
+  test('should update to display the current time every second', async () => {
+    const textElement = app.root.findByType('Text');
+
+    expect(textElement.children[0]).toEqual('12:00:00 AM');
 
     clock.tick(2000);
-    expect(getByText('12:00:02 AM')).toBeDefined();
+    expect(textElement.children[0]).toEqual('12:00:02 AM');
 
     clock.tick(8500);
-    expect(getByText('12:00:10 AM')).toBeDefined();
+    expect(textElement.children[0]).toEqual('12:00:10 AM');
   });
 
   test('should clean up the interval timer when the component is unmounted', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17823,15 +17823,6 @@
         }
       }
     },
-    "react-native-testing-library": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/react-native-testing-library/-/react-native-testing-library-1.14.0.tgz",
-      "integrity": "sha512-AzWmhe4VfkaWAvetqsbQkPVC/aMcixj26WMxtiOpXRXsKuqwR3ijQMAG/OjO5IXNixueO0VoPhvL4FeDfDtBKQ==",
-      "dev": true,
-      "requires": {
-        "pretty-format": "^26.0.1"
-      }
-    },
     "react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "react": "^16.12.0",
     "react-dom": "^16.13.0",
     "react-native": "^0.63.4",
-    "react-native-testing-library": "^1.12.0",
     "react-router-dom": "^5.2.0",
     "react-test-renderer": "^17.0.1",
     "rollup": "^2.38.0",


### PR DESCRIPTION
Proposed changes:
- remove `@testing-library/react-native`
- use `react-test-renderer`

`@testing-library/react-native` was behind several major version. The newest version breaks with sinon's fake timer (also implemented in jest)